### PR TITLE
Throw an exception instantly if the specified config file contains invalid config

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -59,7 +59,10 @@ object ScalafmtPlugin extends AutoPlugin {
       c.map { f =>
           StyleCache.getStyleForFileOrError(f.toString).toEither match {
             case Right(conf) => conf
-            case Left(configErr) => sys.error(configErr.msg)
+            case Left(configErr) =>
+              throw new MessageOnlyException(
+                configErr.msg
+              )
           }
         }
         .getOrElse(ScalafmtConfig.default)

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -56,7 +56,12 @@ object ScalafmtPlugin extends AutoPlugin {
 
   private val scalaConfig =
     scalafmtConfig.map { c =>
-      c.flatMap(f => StyleCache.getStyleForFile(f.toString))
+      c.map { f =>
+          StyleCache.getStyleForFileOrError(f.toString).toEither match {
+            case Right(conf) => conf
+            case Left(configErr) => sys.error(configErr.msg)
+          }
+        }
         .getOrElse(ScalafmtConfig.default)
     }
   private val sbtConfig = scalaConfig.map(_.forSbt)


### PR DESCRIPTION
Addresses https://github.com/scalameta/sbt-scalafmt/issues/7

As this PR, if the specified config file contains invalid config, sbt-scalafmt throw an exception instantly.
For example, 

### .scalafmt.conf
```
# correct: assumeStandardLibraryStripMargin 
assumndardLibraryStripMargin = true
```

### Execution

```
sbt:test-project> scalafmt
[error] java.lang.RuntimeException: Invalid field: assumndardLibraryStripMargin. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
[error]         at scala.sys.package$.error(package.scala:27)
[error]         at org.scalafmt.sbt.ScalafmtPlugin$.$anonfun$scalaConfig$2(ScalafmtPlugin.scala:62)
...
[error]         at java.lang.Thread.run(Thread.java:745)
[error] (Compile / scalafmt) Invalid field: assumndardLibraryStripMargin. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
[error] Total time: 0 s, completed 2018/07/30 1:46:59
```
