### PR TITLE
Fix the result of scalafmtCheck

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -158,7 +158,7 @@ object ScalafmtPlugin extends AutoPlugin {
             s"${file.toString} isn't formatted properly!"
           )
         }
-        diff
+        !diff
       }
     ).flatten.forall(x => x)
     res


### PR DESCRIPTION
scalafmtCheck would return false when all sources are well-formatted because on each file check it was testing that the result is different from the original when it's supposed to check that they are the same. 