### PR TITLE
Add scalafmtAll and scalafmtCheckAll tasks

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -58,7 +58,7 @@ object ScalafmtPlugin extends AutoPlugin {
         "(By default this means the Compile and Test configurations.)"
     )
     val scalafmtCheckAll = taskKey[Unit](
-      "Execute the scalafmtCheck task for all configurations in which it is enabled." +
+      "Execute the scalafmtCheck task for all configurations in which it is enabled. " +
         "(By default this means the Compile and Test configurations.)"
     )
   }

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -53,6 +53,14 @@ object ScalafmtPlugin extends AutoPlugin {
           "Does not write to files."
       )
     val scalafmtOnly = inputKey[Unit]("Format a single given file.")
+    val scalafmtAll = taskKey[Unit](
+      "Execute the scalafmt task for all configurations in which it is enabled. " +
+        "(By default this means the Compile and Test configurations.)"
+    )
+    val scalafmtCheckAll = taskKey[Unit](
+      "Execute the scalafmtCheck task for all configurations in which it is enabled." +
+        "(By default this means the Compile and Test configurations.)"
+    )
   }
   import autoImport._
 
@@ -268,8 +276,15 @@ object ScalafmtPlugin extends AutoPlugin {
     }
   )
 
+  private val anyConfigsInThisProject = ScopeFilter(
+    configurations = inAnyConfiguration
+  )
+
   override def projectSettings: Seq[Def.Setting[_]] =
-    Seq(Compile, Test).flatMap(inConfig(_)(scalafmtConfigSettings))
+    Seq(Compile, Test).flatMap(inConfig(_)(scalafmtConfigSettings)) ++ Seq(
+      scalafmtAll := scalafmt.?.all(anyConfigsInThisProject).value,
+      scalafmtCheckAll := scalafmtCheck.?.all(anyConfigsInThisProject).value
+    )
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
     scalafmtConfig := {

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -34,8 +34,10 @@ lazy val p7 = project.settings(
   scalaVersion := "2.12.1",
   scalafmtConfig := None
 )
-
 lazy val p8 = project.settings(
+  scalaVersion := "2.12.1"
+)
+lazy val p9 = project.settings(
   scalaVersion := "2.12.1"
 )
 
@@ -185,6 +187,29 @@ TaskKey[Unit]("check") := {
       |    a: Int, // comment
       |    b: Double
       |  ) = ???
+      |}
+    """.stripMargin
+  )
+
+  assertContentsEqual(
+    file(s"p9/src/main/scala/Test.scala"),
+    """
+      |object Test {
+      |  foo(
+      |    a, // comment
+      |    b
+      |  )
+      |}
+    """.stripMargin
+  )
+  assertContentsEqual(
+    file(s"p9/src/test/scala/MainTest.scala"),
+    """
+      |object MainTest {
+      |  foo(
+      |    a, // comment
+      |    b
+      |  )
       |}
     """.stripMargin
   )

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p9/src/main/scala/Test.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p9/src/main/scala/Test.scala
@@ -1,0 +1,6 @@
+object
+Test
+{
+  foo(a, // comment
+    b)
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p9/src/test/scala/MainTest.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p9/src/test/scala/MainTest.scala
@@ -1,0 +1,6 @@
+object
+MainTest
+{
+  foo(a, // comment
+    b)
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/project/build.properties
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.1

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/project/build.properties
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.1

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -28,6 +28,8 @@
 > p7/compile:scalafmtCheck
 > p7/test:scalafmtCheck
 
+> p9/scalafmtAll
+
 > p8/compile:scalafmt
 > check
 $ sleep 1000


### PR DESCRIPTION
These new tasks execute the `scalafmt` and `scalafmtCheck` tasks respectively, for all configurations in which they are enabled.

This means you can easily check or format your production code, tests, integration tests, etc. at once.

Fixes https://github.com/scalameta/scalafmt/issues/1335 (which apparently I opened in the wrong place - feel free to transfer the issue over to this repo)