### PR TITLE
Change organization to org.scalameta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    organization := "com.geirsson",
+    organization := "org.scalameta",
     homepage := Some(url("https://github.com/scalameta/sbt-scalafmt")),
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -229,7 +229,7 @@ TaskKey[Unit]("check") := {
     file("project/plugins.sbt"),
     """
       |addSbtPlugin(
-      |  "com.geirsson" % "sbt-scalafmt" % System.getProperty("plugin.version")
+      |  "org.scalameta" % "sbt-scalafmt" % System.getProperty("plugin.version")
       |)
       |resolvers += Resolver.sonatypeRepo("releases")
     """.stripMargin

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/project/plugins.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin   (
-  "com.geirsson" % "sbt-scalafmt" % System.getProperty("plugin.version"))
+  "org.scalameta" % "sbt-scalafmt" % System.getProperty("plugin.version"))
 resolvers += Resolver.sonatypeRepo("releases")
 


### PR DESCRIPTION
Change the organization to org.scalameta before cutting the new release (2.0.0-RC5)
See the details:  https://github.com/scalameta/scalafmt/commit/a1989b18a34357c0ba1ace091241f4b62df767fb