### PR TITLE
Incremental formatting by default

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -108,8 +108,11 @@ object ScalafmtPlugin extends AutoPlugin {
       writer: PrintWriter
   ): Unit = {
     cached(cacheDirectory, FilesInfo.lastModified) { modified =>
-      log.info(s"Formatting ${modified.size} Scala sources...")
-      formatSources(modified.toSeq, config, log, writer)
+      val changed = modified.filter(_.exists)
+      if (changed.size > 0) {
+        log.info(s"Formatting ${changed.size} Scala sources...")
+        formatSources(changed.toSeq, config, log, writer)
+      }
     }(sources.toSet).getOrElse(())
   }
 
@@ -148,8 +151,13 @@ object ScalafmtPlugin extends AutoPlugin {
       writer: PrintWriter
   ): Boolean = {
     cached[Boolean](cacheDirectory, FilesInfo.lastModified) { modified =>
-      log.info(s"Checking ${modified.size} Scala sources...")
-      checkSources(modified.toSeq, config, log, writer)
+      val changed = modified.filter(_.exists)
+      if (changed.size > 0) {
+        log.info(s"Formatting ${changed.size} Scala sources...")
+        checkSources(changed.toSeq, config, log, writer)
+      } else {
+        true
+      }
     }(sources.toSet).getOrElse(true)
   }
 


### PR DESCRIPTION
Based on discussion in #13 

1. Incremental formatting enabled by default for `scalafmt`, `scalafmtCheck` and `scalafmtAll` commands
2. Removed `scalafmtIncremental` task

Unfortunately, I could not find a way to detect changes in `.sbt` and `project/.scala` files. So those files will be formatted without cache usage. I think that it is not big problem because usually there are not very many such files.