### PR TITLE
Use global instance, so that caching actually works, fixes #25

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -75,6 +75,8 @@ object ScalafmtPlugin extends AutoPlugin {
   private type Input = String
   private type Output = String
 
+  val globalInstance = Scalafmt.create(this.getClass.getClassLoader)
+
   private def withFormattedSources[T](
       sources: Seq[File],
       config: Path,
@@ -85,8 +87,7 @@ object ScalafmtPlugin extends AutoPlugin {
       onFormat: (File, Input, Output) => T
   ): Seq[Option[T]] = {
     val reporter = new ScalafmtSbtReporter(log, writer)
-    val scalafmtInstance =
-      Scalafmt.create(this.getClass.getClassLoader).withReporter(reporter)
+    val scalafmtInstance = globalInstance.withReporter(reporter)
     sources
       .map { file =>
         val input = IO.read(file)


### PR DESCRIPTION
Maybe contra-intuitively `ServiceLoader.load` in `Scalafmt.create` creates new instances all the time, so the caching in `ScalafmtDynamic` isn't used at all. With this fixed interactive usage in sbt is now much faster.