### PR TITLE
Do not leave scalafmtIncremental undefined to avoid a breaking change.

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -24,7 +24,7 @@ object ScalafmtPlugin extends AutoPlugin {
   object autoImport {
     val scalafmt = taskKey[Unit]("Format Scala sources with scalafmt.")
     val scalafmtIncremental = taskKey[Unit](
-      "Format Scala sources to be compiled incrementally with scalafmt."
+      "Format Scala sources to be compiled incrementally with scalafmt (alias to scalafmt)."
     )
     val scalafmtCheck =
       taskKey[Boolean](
@@ -222,6 +222,7 @@ object ScalafmtPlugin extends AutoPlugin {
       streams.value.log,
       streams.value.text()
     ),
+    scalafmtIncremental := scalafmt.value,
     scalafmtSbt := {
       formatSources(
         sbtSources.value,

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -23,6 +23,8 @@ object ScalafmtPlugin extends AutoPlugin {
 
   object autoImport {
     val scalafmt = taskKey[Unit]("Format Scala sources with scalafmt.")
+
+    @deprecated("Use scalafmt instead.", "2.0.0")
     val scalafmtIncremental = taskKey[Unit](
       "Format Scala sources to be compiled incrementally with scalafmt (alias to scalafmt)."
     )


### PR DESCRIPTION
- Now `scalafmt` task has an incremental feature by default (thanks to https://github.com/scalameta/sbt-scalafmt/pull/23)
- Based on the advice https://github.com/scalameta/sbt-scalafmt/pull/23#issuecomment-472446677, we keep `scalafmtIncremental` task to avoid a breaking change.