### PR TITLE
Fix false positive and false negative cache hits

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/Difference.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/Difference.scala
@@ -1,0 +1,64 @@
+package org.scalafmt.sbt
+
+import java.io.File
+
+import sbt.io.IO
+import sbt.util.{CacheStore, ChangeReport, FileInfo, FilesInfo, Tracked}
+
+// Originally copied from https://github.com/sbt/util/blob/7431dbd/util-tracking/src/main/scala/sbt/util/Tracked.scala
+class Difference(
+    val store: CacheStore,
+    val style: FileInfo.Style,
+    val defineClean: Boolean,
+    val filesAreOutputs: Boolean
+) extends Tracked {
+  def clean() = {
+    if (defineClean) IO.delete(raw(cachedFilesInfo)) else ()
+    clearCache()
+  }
+
+  private def clearCache() = store.delete()
+
+  private def cachedFilesInfo =
+    store.read(default = FilesInfo.empty[style.F])(style.formats).files
+  private def raw(fs: Set[style.F]): Set[File] = fs.map(_.file)
+
+  def apply[T](files: Set[File])(f: ChangeReport[File] => T): T = {
+    val lastFilesInfo = cachedFilesInfo
+    apply(files, lastFilesInfo)(f)(_ => files)
+  }
+
+  def apply[T](
+      f: ChangeReport[File] => T
+  )(implicit toFiles: T => Set[File]): T = {
+    val lastFilesInfo = cachedFilesInfo
+    apply(raw(lastFilesInfo), lastFilesInfo)(f)(toFiles)
+  }
+
+  private def abs(files: Set[File]) = files.map(_.getAbsoluteFile)
+
+  private[this] def apply[T](files: Set[File], lastFilesInfo: Set[style.F])(
+      f: ChangeReport[File] => T
+  )(extractFiles: T => Set[File]): T = {
+    val lastFiles = raw(lastFilesInfo)
+    val currentFiles = abs(files)
+    val currentFilesInfo = style(currentFiles)
+
+    val report = new ChangeReport[File] {
+      lazy val checked = currentFiles
+      lazy val removed = lastFiles -- checked // all files that were included previously but not this time.  This is independent of whether the files exist.
+      lazy val added = checked -- lastFiles // all files included now but not previously.  This is independent of whether the files exist.
+      lazy val modified = raw(lastFilesInfo -- currentFilesInfo.files) ++ added
+      lazy val unmodified = checked -- modified
+    }
+
+    val result = f(report)
+    val info =
+      if (filesAreOutputs) style(abs(extractFiles(result)))
+      else currentFilesInfo
+
+    store.write(info)(style.formats)
+
+    result
+  }
+}

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -84,7 +84,6 @@ object ScalafmtPlugin extends AutoPlugin {
       log: Logger,
       writer: PrintWriter
   )(
-      onError: (File, Throwable) => T,
       onFormat: (File, Input, Output) => T
   ): Seq[Option[T]] = {
     val reporter = new ScalafmtSbtReporter(log, writer)
@@ -125,10 +124,6 @@ object ScalafmtPlugin extends AutoPlugin {
       writer: PrintWriter
   ): Unit = {
     val cnt = withFormattedSources(sources, config, log, writer)(
-      (file, e) => {
-        log.err(e.toString)
-        0
-      },
       (file, input, output) => {
         if (input != output) {
           IO.write(file, output)
@@ -170,10 +165,6 @@ object ScalafmtPlugin extends AutoPlugin {
       writer: PrintWriter
   ): Boolean = {
     val unformattedCount = withFormattedSources(sources, config, log, writer)(
-      (file, e) => {
-        log.err(e.toString)
-        false
-      },
       (file, input, output) => {
         val diff = input != output
         if (diff) {

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -208,18 +208,18 @@ object ScalafmtPlugin extends AutoPlugin {
       filesAreOutputs = true
     )
     sourceFiles =>
-      val input = sourceFiles + config.toFile
+      val configFile = config.toAbsolutePath.toFile
+      val input = sourceFiles + configFile
 
       val reportHandler: ChangeReport[File] => Option[UnformattedSources] = {
         outReport =>
           val updatedOrAdded = outReport.modified -- outReport.removed
           if (!updatedOrAdded.isEmpty) {
-            val cacheMisses = updatedOrAdded.intersect(sourceFiles)
-            if (!cacheMisses.isEmpty) {
+            if (!updatedOrAdded.contains(configFile)) {
               // partial cache hit, incremental run
-              Some(action(cacheMisses))
+              Some(action(updatedOrAdded))
             } else {
-              // config file must have changed, rerun everything
+              // config file has changed, rerun everything
               Some(action(sourceFiles))
             }
           } else {

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -67,6 +67,9 @@ lazy val p16 = project.settings(
   scalaVersion := "2.12.1",
   scalafmtConfig := file(".scalafmt16.conf")
 )
+lazy val p17 = project.settings(
+  scalaVersion := "2.12.1",
+)
 
 def assertContentsEqual(file: File, expected: String): Unit = {
   val obtained =

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p15/src/test/scala/Test2.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p15/src/test/scala/Test2.scala
@@ -1,0 +1,6 @@
+object
+Test2
+{
+  def foo2(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p16/src/test/scala/Test2.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p16/src/test/scala/Test2.scala
@@ -1,0 +1,6 @@
+object
+Test2
+{
+  def foo2(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p17/src/main/scala/Test.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p17/src/main/scala/Test.scala
@@ -1,0 +1,7 @@
+// already formatted!
+object Test {
+  foo(
+    a, // comment
+    b
+  )
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p17/src/test/scala/Test2.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p17/src/test/scala/Test2.scala
@@ -1,0 +1,6 @@
+object
+Test2
+{
+  def foo2(a: Int, // comment
+           b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -107,3 +107,13 @@ $ exec chmod 000 p15/src/main/scala/Test.scala
 $ exec chmod 000 p16/src/main/scala/Test.scala
 -> p16/scalafmt
 -> p16/scalafmtCheck
+
+$ copy-file p17/src/test/scala/Test2.scala p17/src/main/scala/Test2.scala
+-> p17/scalafmtCheck
+# prevent reading the source (without changing the mtime) to detect actual/uncached invocation of scalafmt
+$ exec chmod 000 p17/src/main/scala/Test.scala
+######## incremental checking expected when all previous validations failed on some sources only
+> p17/test:scalafmt
+$ copy-file p17/src/test/scala/Test2.scala p17/src/main/scala/Test2.scala
+> p17/scalafmtCheck
+> p17/scalafmt

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -94,17 +94,29 @@ $ touch p14/src/main/scala/Test.scala
 
 > p15/scalafmt
 > p15/scalafmtCheck
-$ copy-file .scalafmt.conf .scalafmt15.conf
 # prevent reading the source (without changing the mtime) to detect actual/uncached invocation of scalafmt
 $ exec chmod 000 p15/src/main/scala/Test.scala
+######## full run expected when config was updated and a source file added since last run
+$ copy-file .scalafmt.conf .scalafmt15.conf
+$ copy-file p15/src/test/scala/Test2.scala p15/src/main/scala/Test2.scala
+-> p15/scalafmt
+-> p15/scalafmtCheck
+######## full run expected when only config was updated since last run
+$ delete p15/src/main/scala/Test2.scala
 -> p15/scalafmt
 -> p15/scalafmtCheck
 
 > p16/scalafmt
 > p16/scalafmtCheck
-> set p16/scalafmtConfig := file(".scalafmt.conf")
 # prevent reading the source (without changing the mtime) to detect actual/uncached invocation of scalafmt
 $ exec chmod 000 p16/src/main/scala/Test.scala
+######## full run expected when config was updated and a source file added since last run
+> set p16/scalafmtConfig := file(".scalafmt.conf")
+$ copy-file p16/src/test/scala/Test2.scala p16/src/main/scala/Test2.scala
+-> p16/scalafmt
+-> p16/scalafmtCheck
+######## full run expected when only config was updated since last run
+$ delete p16/src/main/scala/Test2.scala
 -> p16/scalafmt
 -> p16/scalafmtCheck
 


### PR DESCRIPTION
Fix behavior that has been around since the introduction of the cache it seems:
* closes scalameta/sbt-scalafmt#42 (false negative caching)
* closes scalameta/sbt-scalafmt#45 (false positive caching)

Still early, this definitely needs manual testing as I only relied on scripted tests (which are getting better but far from exhaustive).

The test describing the issue pass from the third commit (2 first commits are cosmetic/non-functionnal), but the implementation clearly reaches the limit of the sbt helpers (from what I can tell at least) as it requires the usage of an exception to bypass cache storage at first, and a second call to mark files selectively...

So I went ahead and tried to hack the sbt helpers. [`sbt.util.Difference`](https://github.com/sbt/util/blob/7431dbd/util-tracking/src/main/scala/sbt/util/Tracked.scala#L280-L330) is pretty closed, so I had to inline it to extend it as I needed. I tried to remain binary compatible, so it might be possible to push it upstream as this seems like a recurring pattern for source formatting plugins. An advantage of the new method signature is that it allows to skip cache update on disk when cache was hit (not tested/enforced at the moment though).