### PR TITLE
Update to the latest Scalafmt that doesn't use coursier-small

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ inThisBuild(
         url("https://github.com/tanishiking/")
       )
     ),
-    resolvers += Resolver.sonatypeRepo("releases"),
+    resolvers += Resolver.sonatypeRepo("public"),
     scalaVersion := "2.12.8",
     publishArtifact in packageDoc := sys.env.contains("CI"),
     publishArtifact in packageSrc := sys.env.contains("CI")
@@ -39,7 +39,7 @@ lazy val plugin = project
   .settings(
     moduleName := "sbt-scalafmt",
     libraryDependencies ++= List(
-      "org.scalameta" %% "scalafmt-dynamic" % "2.0.0"
+      "org.scalameta" %% "scalafmt-dynamic" % "2.1.0-RC2"
     ),
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}"

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -1,6 +1,6 @@
 package org.scalafmt.sbt
 
-import java.io.PrintWriter
+import java.io.OutputStreamWriter
 import java.nio.file.Path
 
 import sbt.Keys._
@@ -94,7 +94,7 @@ object ScalafmtPlugin extends AutoPlugin {
       sources: Seq[File],
       config: Path,
       log: Logger,
-      writer: PrintWriter
+      writer: OutputStreamWriter
   )(
       onFormat: (File, Input, Output) => T
   ): Seq[Option[T]] = {
@@ -118,7 +118,7 @@ object ScalafmtPlugin extends AutoPlugin {
       sources: Seq[File],
       config: Path,
       log: Logger,
-      writer: PrintWriter
+      writer: OutputStreamWriter
   ): Unit = {
     trackSourcesAndConfig(cacheStoreFactory, sources, config) {
       (outDiff, configChanged, prev) =>
@@ -143,7 +143,7 @@ object ScalafmtPlugin extends AutoPlugin {
       sources: Set[File],
       config: Path,
       log: Logger,
-      writer: PrintWriter
+      writer: OutputStreamWriter
   ): Unit = {
     val cnt = withFormattedSources(sources.toSeq, config, log, writer)(
       (file, input, output) => {
@@ -167,7 +167,7 @@ object ScalafmtPlugin extends AutoPlugin {
       sources: Seq[File],
       config: Path,
       log: Logger,
-      writer: PrintWriter
+      writer: OutputStreamWriter
   ): ScalafmtAnalysis = {
     trackSourcesAndConfig(cacheStoreFactory, sources, config) {
       (outDiff, configChanged, prev) =>
@@ -205,7 +205,7 @@ object ScalafmtPlugin extends AutoPlugin {
       sources: Seq[File],
       config: Path,
       log: Logger,
-      writer: PrintWriter
+      writer: OutputStreamWriter
   ): ScalafmtAnalysis = {
     if (sources.nonEmpty) {
       log.info(s"Checking ${sources.size} Scala sources...")
@@ -282,7 +282,7 @@ object ScalafmtPlugin extends AutoPlugin {
         (unmanagedSources in scalafmt).value,
         scalaConfig.value,
         streams.value.log,
-        streams.value.text()
+        outputStreamWriter(streams.value)
       )
     },
     scalafmtIncremental := scalafmt.value,
@@ -291,13 +291,13 @@ object ScalafmtPlugin extends AutoPlugin {
         sbtSources.value.toSet,
         sbtConfig.value,
         streams.value.log,
-        streams.value.text()
+        outputStreamWriter(streams.value)
       )
       formatSources(
         metabuildSources.value.toSet,
         scalaConfig.value,
         streams.value.log,
-        streams.value.text()
+        outputStreamWriter(streams.value)
       )
     },
     scalafmtCheck := {
@@ -306,7 +306,7 @@ object ScalafmtPlugin extends AutoPlugin {
         (unmanagedSources in scalafmt).value,
         scalaConfig.value,
         streams.value.log,
-        streams.value.text()
+        outputStreamWriter(streams.value)
       )
       trueOrBoom(analysis)
     },
@@ -316,7 +316,7 @@ object ScalafmtPlugin extends AutoPlugin {
           sbtSources.value,
           sbtConfig.value,
           streams.value.log,
-          streams.value.text()
+          outputStreamWriter(streams.value)
         )
       )
       trueOrBoom(
@@ -324,7 +324,7 @@ object ScalafmtPlugin extends AutoPlugin {
           metabuildSources.value,
           scalaConfig.value,
           streams.value.log,
-          streams.value.text()
+          outputStreamWriter(streams.value)
         )
       )
     },
@@ -354,10 +354,13 @@ object ScalafmtPlugin extends AutoPlugin {
         absFiles.toSet,
         scalaConfig.value,
         streams.value.log,
-        streams.value.text()
+        outputStreamWriter(streams.value)
       )
     }
   )
+
+  private def outputStreamWriter(streams: TaskStreams): OutputStreamWriter =
+    new OutputStreamWriter(streams.binary())
 
   private val anyConfigsInThisProject = ScopeFilter(
     configurations = inAnyConfiguration

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtReporter.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtReporter.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.sbt
 
 import java.io.PrintWriter
+import java.io.OutputStreamWriter
 import java.nio.file.Path
 
 import org.scalafmt.interfaces.ScalafmtReporter
@@ -9,7 +10,7 @@ import sbt.util.Logger
 
 import scala.util.control.NoStackTrace
 
-class ScalafmtSbtReporter(log: Logger, writer: PrintWriter)
+class ScalafmtSbtReporter(log: Logger, out: OutputStreamWriter)
     extends ScalafmtReporter {
   override def error(file: Path, message: String): Unit = {
     throw new MessageOnlyException(s"$message: $file")
@@ -29,7 +30,8 @@ class ScalafmtSbtReporter(log: Logger, writer: PrintWriter)
   override def parsedConfig(config: Path, scalafmtVersion: String): Unit =
     log.debug(s"parsed config (v$scalafmtVersion): $config")
 
-  override def downloadWriter(): PrintWriter = writer
+  override def downloadWriter(): PrintWriter = new PrintWriter(out)
+  override def downloadOutputStreamWriter(): OutputStreamWriter = out
 
   private class FailedToFormat(filename: String, cause: Throwable)
       extends Exception(filename, cause)


### PR DESCRIPTION
The coursier/interface module requires OutputStreamWriter instead of
PrintWriter, causing the large diff.