### PR TITLE
Managed sources filter

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -275,7 +275,6 @@ object ScalafmtPlugin extends AutoPlugin {
       val projectDirectory = BuildPaths.projectStandard(thisBase)
       val targetDirectory =
         BuildPaths.outputDirectory(projectDirectory).getAbsolutePath
-      println(projectDirectory)
       projectDirectory
         .descendantsExcept(
           "*.scala",

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -271,7 +271,16 @@ object ScalafmtPlugin extends AutoPlugin {
     val rootBase = (LocalRootProject / baseDirectory).value
     val thisBase = (thisProject.value).base
     if (rootBase == thisBase)
-      (BuildPaths.projectStandard(thisBase) ** GlobFilter("*.scala")).get
+      BuildPaths
+        .projectStandard(thisBase)
+        .descendantsExcept(
+          "*.scala",
+          (pathname: File) =>
+            pathname.getAbsolutePath
+              .drop(thisBase.getAbsolutePath.length)
+              .contains("/target/")
+        )
+        .get
     else Nil
   }
 

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -270,18 +270,21 @@ object ScalafmtPlugin extends AutoPlugin {
   private lazy val metabuildSources = Def.task {
     val rootBase = (LocalRootProject / baseDirectory).value
     val thisBase = (thisProject.value).base
-    if (rootBase == thisBase)
-      BuildPaths
-        .projectStandard(thisBase)
+
+    if (rootBase == thisBase) {
+      val projectDirectory = BuildPaths.projectStandard(thisBase)
+      val targetDirectory =
+        BuildPaths.outputDirectory(projectDirectory).getAbsolutePath
+      projectDirectory
         .descendantsExcept(
           "*.scala",
           (pathname: File) =>
-            pathname.getAbsolutePath
-              .drop(thisBase.getAbsolutePath.length)
-              .contains("/target/")
+            pathname.getAbsolutePath.startsWith(targetDirectory)
         )
         .get
-    else Nil
+    } else {
+      Nil
+    }
   }
 
   lazy val scalafmtConfigSettings: Seq[Def.Setting[_]] = Seq(

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -275,6 +275,7 @@ object ScalafmtPlugin extends AutoPlugin {
       val projectDirectory = BuildPaths.projectStandard(thisBase)
       val targetDirectory =
         BuildPaths.outputDirectory(projectDirectory).getAbsolutePath
+      println(projectDirectory)
       projectDirectory
         .descendantsExcept(
           "*.scala",

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -265,3 +265,23 @@ TaskKey[Unit]("check") := {
     """.stripMargin
   )
 }
+
+
+TaskKey[Unit]("checkManagedSources") := {
+  assertContentsEqual(
+    file("project/x/Something.scala"),
+    """
+      |// format me
+      |object kek {}
+      |""".stripMargin
+  )
+
+  assertContentsEqual(
+    file("project/target/managed.scala"),
+    """
+      |// don't touch me!!!
+      |
+      |object a       {}
+      |""".stripMargin
+  )
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/target/managed.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/target/managed.scala
@@ -1,0 +1,3 @@
+// don't touch me!!!
+
+object a       {}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/x/Something.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/x/Something.scala
@@ -1,0 +1,2 @@
+// format me
+object kek    {}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/project/target/.gitindexing
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/project/target/.gitindexing
@@ -1,0 +1,1 @@
+Empty directory is required for tests

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/project/x/.gitindexing
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/project/x/.gitindexing
@@ -1,0 +1,1 @@
+Empty directory is required for tests

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -142,3 +142,8 @@ $ delete p17/src/main/scala/Test2.scala
 $ copy-file changes/good.scala p17/src/main/scala/Test2.scala
 > p17/scalafmtCheck
 > p17/scalafmt
+
+$ copy-file changes/target/managed.scala project/target/managed.scala
+$ copy-file changes/x/Something.scala project/x/Something.scala
+> scalafmtSbt
+> checkManagedSources


### PR DESCRIPTION
Fixes #51

We ignore `target` directory content by default. If you need to ignore another directory with managed sources you can use `project.excludeFilters` in the configuration.