### PR TITLE
Remove sbt-coursier

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,2 @@
-addSbtPlugin(
-  "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version
-)
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M4")


### PR DESCRIPTION
Since sbt 1.3.x uses coursier for resolving dependencies by default https://www.lightbend.com/blog/sbt-1.3.0-release, and now we can remove sbt-coursier from sbt-scalafmt's build. (and close https://github.com/scalameta/sbt-scalafmt/pull/56)

## Refs
- https://twitter.com/eed3si9n/status/1169295125907943424
- https://github.com/almond-sh/almond/issues/446#issuecomment-538681464