### PR TITLE
Scalafmt-dynamic updated to 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val plugin = project
   .settings(
     moduleName := "sbt-scalafmt",
     libraryDependencies ++= List(
-      "org.scalameta" %% "scalafmt-dynamic" % "2.1.1"
+      "org.scalameta" %% "scalafmt-dynamic" % "2.2.0"
     ),
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}"


### PR DESCRIPTION
I think we should cut `sbt-scalafmt` v2.2.0 and release next plugin improvements as patch versions.

Also I can't update Scala version to 2.13 because of

```
[error] (plugin / update) sbt.librarymanagement.ResolveException: Error downloading org.scala-sbt:scripted-sbt_2.13:1.3.3
```

scripted-sbt is not published for 2.13: https://mvnrepository.com/artifact/org.scala-sbt/scripted-sbt