### PR TITLE
Sbt version revert to 1.2.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.2.8


### PR DESCRIPTION
Unfortunately we can't update sbt version without breaking compatibility.
`sbt-scalafmt` v2.2.0 can't work in projects with sbt v1.2.x and older because sbt 1.3.x isn't compatible with sbt 1.2.x.

So I think we should stay on 1.2.8 as long as possible 😞 