### PR TITLE
Implement error method with an additinal error message and cause

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtReporter.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtReporter.scala
@@ -24,6 +24,14 @@ class ScalafmtSbtReporter(log: Logger, out: OutputStreamWriter)
     }
   }
 
+  override def error(file: Path, message: String, e: Throwable): Unit = {
+    if (e.getMessage != null) {
+      error(file, s"$message: ${e.getMessage()}")
+    } else {
+      throw new FailedToFormat(file.toString, e)
+    }
+  }
+
   override def excluded(file: Path): Unit =
     log.debug(s"file excluded: $file")
 


### PR DESCRIPTION
The first step to tackle this issue: https://github.com/scalameta/scalafmt/issues/1628

Without this implementation, the reporter ends up discarding the error information of the `cause` of `default void error(Path file, String message, Throwable e)`.
For example, the original cause of [CorruptedClassPath](https://github.com/scalameta/scalafmt/blob/dee798a99e16dcf32fea37cdc05d694b76647ada/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala#L96) is discarded, and  currently, we have no clue to tackle this kind of problem: https://github.com/scalameta/scalafmt/issues/1628

Because

- The default implementation of `default void error(Path file, String message, Throwable e)` is something like this: wrapping the additional message with `RuntimeException` and put the original exception to the `cause` of the `RuntimeException`
  - https://github.com/scalameta/scalafmt/blob/dee798a99e16dcf32fea37cdc05d694b76647ada/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtReporter.java#L29-L39
- SbtScalafmtReporter doesn't show the information of the `cause` if there's a message:
  - https://github.com/scalameta/sbt-scalafmt/blob/ed2efe28b30d6d12eaa2e3b9cbaf6f70c7e4f94d/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtReporter.scala#L19-L25

---

So this PR enables SbtScalafmtReporter to show the original error message passed via the third argument of `default void error(Path file, String message, Throwable e)`.