### PR TITLE
add sbt.ConcurrentRestrictions.Tag("scalafmt") + Tags.CPU on scalafmt tasks

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ConcurrentRestrictionTags.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ConcurrentRestrictionTags.scala
@@ -1,0 +1,18 @@
+package org.scalafmt.sbt
+
+trait ConcurrentRestrictionTags {
+  import sbt.ConcurrentRestrictions.Tag
+
+  /**
+    * This tag can be used to control the maximum number of parallel scalafmt tasks in large-scale build trees.
+    *
+    * Global / concurrentRestrictions ++= Tags.limit(org.scalafmt.sbt.ConcurrentRestrictionTags.Scalafmt, 3)
+    *
+    * would prevent SBT from spawning more than three simultaneous Scalafmt tasks
+    *
+    * @see https://www.scala-sbt.org/1.x/docs/Parallel-Execution.html
+    */
+  val Scalafmt = Tag("scalafmt")
+}
+
+object ConcurrentRestrictionTags extends ConcurrentRestrictionTags

--- a/plugin/src/main/scala/org/scalafmt/sbt/ConcurrentRestrictionTags.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ConcurrentRestrictionTags.scala
@@ -6,7 +6,7 @@ trait ConcurrentRestrictionTags {
   /**
     * This tag can be used to control the maximum number of parallel scalafmt tasks in large-scale build trees.
     *
-    * Global / concurrentRestrictions ++= Tags.limit(org.scalafmt.sbt.ConcurrentRestrictionTags.Scalafmt, 3)
+    * Global / concurrentRestrictions += Tags.limit(org.scalafmt.sbt.ConcurrentRestrictionTags.Scalafmt, 3)
     *
     * would prevent SBT from spawning more than three simultaneous Scalafmt tasks
     *


### PR DESCRIPTION
When a project aggregates many projects, running scalafmt may kick of many, many tasks in parallel (the itch being scratched here is a build where one of the first task sets is multiple dozens of scalafmt rushing all at once against a puny 8C16T cpu socket)

While SBT's defaults should cause reasonable limits, having an explicit `sbt.ConcurrentRestrictions.Tag("scalafmt")` may enable a build to allocate a different quota of CPU cores during the build.

https://www.scala-sbt.org/1.x/docs/Parallel-Execution.html

After this PR, a user may do things like

```
Global / concurrentRestrictions := {
  val cpus = java.lang.Runtime.getRuntime.getAvailableProcessors

  Seq(
    Tags.limit(Tags.CPU, cpus),
    Tags.limit(ScalafmtTag, 3),
    Tags.limit(Tags.Network, 10),
    Tags.limit(Tags.Test, 1),
    Tags.limitAll( 4 * cpus )
  )
}
```