### PR TITLE
Don't throw error if no version specified

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val plugin = project
   .settings(
     moduleName := "sbt-scalafmt",
     libraryDependencies ++= List(
-      "org.scalameta" %% "scalafmt-dynamic" % "2.1.0-RC2"
+      "org.scalameta" %% "scalafmt-dynamic" % "2.1.0"
     ),
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}"

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -112,6 +112,7 @@ object ScalafmtPlugin extends AutoPlugin {
       globalInstance
         .withReporter(reporter)
         .withMavenRepositories(repositories: _*)
+        .withRespectVersion(false)
         .withRespectProjectFilters(true) match {
         case t: ScalafmtSessionFactory =>
           val session = t.createSession(config.toAbsolutePath)

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -57,9 +57,9 @@ $ newer p8/src/main/scala/Test2.scala timestamp
 -> p11/scalafmt
 -> p11/scalafmtCheck
 
-# scalafmt fails if version setting is missing.
--> p12/scalafmt
--> p12/scalafmtCheck
+# scalafmt does not fail if version setting is missing.
+> p12/scalafmt
+> p12/scalafmtCheck
 
 > check
 


### PR DESCRIPTION
[Version](https://github.com/scalameta/sbt-scalafmt/blob/master/build.sbt#L42) of scalafmt-dynamic will be used

Fixes #114 