### PR TITLE
Dependency: update scalafmt-dynamic to 3.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val plugin = project
   .settings(
     moduleName := "sbt-scalafmt",
     libraryDependencies ++= List(
-      "org.scalameta" %% "scalafmt-dynamic" % "3.0.8"
+      "org.scalameta" %% "scalafmt-dynamic" % "3.1.1"
     ),
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}"

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -118,7 +118,6 @@ object ScalafmtPlugin extends AutoPlugin {
       globalInstance
         .withReporter(reporter)
         .withMavenRepositories(repositories: _*)
-        .withRespectVersion(false)
         .withRespectProjectFilters(true) match {
         case t: ScalafmtSessionFactory =>
           val session = t.createSession(config.toAbsolutePath)

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/.scalafmt12.conf
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/.scalafmt12.conf
@@ -1,1 +1,3 @@
+version = 3.1.0
+runner.dialect = scala213
 style = IntelliJ


### PR DESCRIPTION
This new version requires an explicit version and fails on usage of `.withRespectVersion(false)`.