### PR TITLE
fix false positive cache invalidation caused by unscoped lookup

### DIFF
--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -142,6 +142,10 @@ $ delete p17/src/main/scala/Test2.scala
 $ copy-file changes/good.scala p17/src/main/scala/Test2.scala
 > p17/scalafmtCheck
 > p17/scalafmt
+######## formatting other config should not invalidate the cache
+$ copy-file changes/bad.scala p17/src/test/scala/Test3.scala
+> p17/test:scalafmt
+> p17/scalafmtCheck
 
 # set up git
 $ exec git init -b main p18


### PR DESCRIPTION
Fix regression introduced in https://github.com/scalameta/sbt-scalafmt/commit/bb360312454b53bf0bc31d0b870f27ca4549d3f5,  effectively disabling the cache for projects with files in several configuration. This is particularly annoying with `scalafmtOnCompile := true`.

The problem is visible by looking at a [stamp file](https://github.com/scalameta/sbt-scalafmt/blob/f8f13675488c2b9c0bb3eef38a466f56698fc213/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala#L343) on a project with 4 configurations after running `sbt clean scalafixAll`
```
# 2.4.3
bjaglin@x1:~/project/target/streams$ find -name output-diff
./it/scalafmt/_global/streams/output-diff
./uit/scalafmt/_global/streams/output-diff
./compile/scalafmt/_global/streams/output-diff
./test/scalafmt/_global/streams/output-diff
```
```
# 2.4.4
bjaglin@x1:~/project/target/streams$ find -name output-diff
./_global/_global/_global/streams/output-diff
```
```
# 2.4.5
bjaglin@x1:~/project/target/streams$ find -name output-diff
./_global/_global/_global/streams/output-diff
```
```
# 2.4.5+9-d5456570-SNAPSHOT
bjaglin@x1:~/project/target/streams$ find -name output-diff
./it/scalafmt/_global/streams/output-diff
./uit/scalafmt/_global/streams/output-diff
./compile/scalafmt/_global/streams/output-diff
./test/scalafmt/_global/streams/output-diff
```

