### PR TITLE
Use canonical paths, not just absolute

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -171,15 +171,15 @@ object ScalafmtPlugin extends AutoPlugin {
       scalafmtSession
     }
 
-    @inline private def baseDir: File = currentProject.base
+    private lazy val baseDir: File = currentProject.base.getCanonicalFile
 
     @inline private def asRelative(file: File): File =
       file.relativeTo(baseDir).getOrElse(file)
 
     private def filterFiles(sources: Seq[File]): Seq[File] = {
       val filter = getFileFilter()
-      sources.distinct.filter { file =>
-        val path = file.toPath.toAbsolutePath
+      sources.map(_.getCanonicalFile).distinct.filter { file =>
+        val path = file.toPath
         scalafmtSession.matchesProjectFilters(path) && filter(path)
       }
     }


### PR DESCRIPTION
Otherwise, filtering might possibly fail.