### PR TITLE
Add sbt-vspp for publishing the SBT plug-in in a Maven-consistent format

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")
+addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.13")

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,11 @@ Add following line into `project/plugins.sbt` (latest version is available next 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % PLUGIN_VERSION)
 ```
 
+If the above does not work, in enterprise environments, try:
+```sbt
+libraryDependencies += "org.scalameta" % "sbt-scalafmt_2.12_1.0" % PLUGIN_VERSION
+```
+
 ### [User documentation](https://scalameta.org/scalafmt/)
 Head over to [the user docs](https://scalameta.org/scalafmt/docs/installation.html#sbt) for instructions on how to install and use scalafmt.
 


### PR DESCRIPTION
Hi! Hope you don't mind me making this PR to request to publish Maven-consistent format of this plugin alongside the existing artifact format.

This is to enable usage of sbt-scalafmt in Enterprise environments where only the valid-POM format is accepted for JAR downloads, enabling advanced Scala capabilities for many many environments. Currently the only way to use it is by manual republishing but we rather any updates get made available automatically.

The only change this does is to add extra JAR and POM to the released artifact (while keeping the old structure) -- notice how currently when you click on 'Browse' on here https://search.maven.org/artifact/org.scalameta/sbt-scalafmt/2.4.6/jar - it goes to a 404 Not Found page -- this is because of the inconsistent / invalid POM.

More background here: https://github.com/esbeetee/sbt-vspp/blob/main/README.md