### PR TITLE
deps: bump sbt to 1.8.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,0 @@
-updates.ignore = [ { groupId = "org.scala-sbt" } ]

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,10 @@ lazy val plugin = project
       "org.scalameta" %% "scalafmt-dynamic" % scalafmtVersion
     ),
     scriptedBufferLog := false,
-    scriptedLaunchOpts += s"-Dplugin.version=${version.value}"
+    scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
+    // For compat reasons we have this in here to ensure we are testing against 1.2.8
+    // We honestly probably don't need to, so if this ever causes issues, rip it out.
+    pluginCrossBuild / sbtVersion := "1.2.8"
   )
 
 // For some reason, it doesn't work if this is defined in globalSettings in PublishPlugin.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.8.0


### PR DESCRIPTION
We use 1.8.0 to build sbt-scalafmt, but we use `pluginCrossBuild / sbtVersion`
to ensure everything is still working against 1.2.8 by compiling against it.
