### PR TITLE
refactor(ci): switch from setup-scala to setup-java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [adopt@1.8]
+        java: [ '8' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v13
+      - name: Set up JVM
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: 'sbt'
+
       - run: git fetch --tags -f
       - run:
           # for git tests
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - run: sbt plugin/scripted
+
   formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
+
       - run: ./bin/scalafmt --test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,22 @@
 name: Release
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     tags: ["*"]
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v13
-      - uses: olafurpg/setup-gpg@v3
-      - run: git fetch --tags --unshallow -f || true
-      - name: Publish ${{ github.ref }}
-        run: sbt ci-release
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
+      - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
This updates to using setup-java which is more actively maintained and recommended now than setup-scala. Plus this has built-in sbt caching. ~In the process of this I've also migrated from `master` -> `main`.~