### PR TITLE
Scalafmt: update to v3.7.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
           cache: 'sbt'
 
       - run: ./bin/scalafmt --test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
           cache: 'sbt'
       - run: sbt ci-release
         env:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.15
+version = 3.7.17
 runner.dialect = scala213
 project.git = true
 project.excludeFilters = [

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ inThisBuild(
 )
 publish / skip := true
 
-val scalafmtVersion = "3.7.15"
+val scalafmtVersion = "3.7.17"
 onLoadMessage := s"Welcome to sbt-scalafmt ${version.value} (scalafmt ${scalafmtVersion})"
 
 lazy val plugin = project


### PR DESCRIPTION
It is now published using java11.