### PR TITLE
Add scalafmtSbtOnCompile setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+.bsp
 
 # sbt specific
 .cache


### PR DESCRIPTION
This adds a counterpart to the `scalafmtOnCompile` setting that enables the `scalafmtSbt` task to run on compile.