### PR TITLE
scalafmt: group parameters, add extra

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,14 +1,21 @@
 version = 3.8.1
 runner.dialect = scala213
-project.git = true
-project.excludeFilters = [
-  plugin/src/sbt-test
-]
+project {
+  git = true
+  excludeFilters = [
+    plugin/src/sbt-test
+  ]
+}
+newlines {
+  avoidForSimpleOverflow = [punct, slc, tooLong]
+  ignoreInSyntax = false
+}
 rewrite {
   rules = [
     Imports,
     RedundantBraces,
-    RedundantParens
+    RedundantParens,
+    SortModifiers
   ]
   imports {
     sort = ascii
@@ -19,7 +26,11 @@ rewrite {
       ["org\\..*"]
     ]
   }
+  sortModifiers.preset = styleGuide
 }
-align.tokens = none
+align {
+  preset = none
+  stripMargin = true
+}
 assumeStandardLibraryStripMargin = true
 onTestFailure = "To fix this, run ./bin/scalafmt from the project root directory"


### PR DESCRIPTION
These extra parameters do not yet change the formatting:
- explicitly align strip margins
- enable SortModifiers
- avoid simple overflow
- don't ignore newlines in syntax
Helps with #305.