### PR TITLE
Tiny improvements to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up JVM
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'sbt'
-
-      - run: git fetch --tags -f
+      - uses: sbt/setup-sbt@v1
       - run:
           # for git tests
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ inThisBuild(List(
   ),
   resolvers ++= Resolver.sonatypeOssRepos("public"),
   scalaVersion := "2.12.20",
-  packageDoc / publishArtifact := sys.env.contains("CI"),
-  packageSrc / publishArtifact := sys.env.contains("CI"),
+  packageDoc / publishArtifact := insideCI.value,
+  packageSrc / publishArtifact := insideCI.value,
 ))
 publish / skip := true
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.8.0")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.13")


### PR DESCRIPTION
* tell `actions/checkout` to fetch tags (instead of a 2nd `git fetch` invocation)
* use `sbt/setup-sbt` to be sure `sbt` is present
* remove no longer needed plugin `sbt-vspp` (see https://github.com/esbeetee/sbt-vspp)
* simplify CI detection in `build.sbt`