### PR TITLE
use `sbt/setup-sbt` to be sure `sbt` is present for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
           cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Followup to #328 