### PR TITLE
Update readme.md with badge and JDK compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # sbt-scalafmt
 [![Join the chat at https://gitter.im/scalameta/scalafmt](https://badges.gitter.im/scalameta/scalafmt.svg)](https://gitter.im/scalameta/scalafmt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join the discord chat](https://img.shields.io/discord/632642981228314653?label=discord)](https://discordapp.com/channels/632642981228314653/632665341864181780)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/sbt-scalafmt/badge.svg?kill_cache=1)](https://search.maven.org/artifact/org.scalameta/sbt-scalafmt/)
+[![Latest version](https://index.scala-lang.org/scalameta/sbt-scalafmt/latest.svg?kill_cache=1)](https://index.scala-lang.org/scalameta/sbt-scalafmt)
 
 This is the repository for the Scalafmt sbt plugin, for the main Scalafmt
 repository see [scalameta/scalafmt](https://github.com/scalameta/scalafmt/).
@@ -18,6 +18,12 @@ If the above does not work, in enterprise environments, try:
 ```sbt
 libraryDependencies += "org.scalameta" % "sbt-scalafmt_2.12_1.0" % PLUGIN_VERSION
 ```
+
+#### JDK compatibility
+| JDK  | Release        |
+| ---- | ---------------|
+| 8    | Up to `v2.5.1` |
+| 11+  | _latest_       |
 
 ### [User documentation](https://scalameta.org/scalafmt/)
 Head over to [the user docs](https://scalameta.org/scalafmt/docs/installation.html#sbt) for instructions on how to install and use scalafmt.


### PR DESCRIPTION
- Update the badge because it was outdated (referencing 2.4.6).
- Add JDK compatibility to indicate drop of Java 8 support.