### PR TITLE
Drop usage of IntegrationTest scope in sbt 2 builds

### DIFF
--- a/plugin/src/main/scala-2/org/scalafmt/sbt/ScalafmtPluginConfigurations.scala
+++ b/plugin/src/main/scala-2/org/scalafmt/sbt/ScalafmtPluginConfigurations.scala
@@ -1,0 +1,7 @@
+package org.scalafmt.sbt
+
+import sbt._
+
+object ScalafmtPluginConfigurations {
+  val supported = Seq(Compile, Test, IntegrationTest)
+}

--- a/plugin/src/main/scala-3/org/scalafmt/sbt/ScalafmtPluginConfigurations.scala
+++ b/plugin/src/main/scala-3/org/scalafmt/sbt/ScalafmtPluginConfigurations.scala
@@ -1,0 +1,7 @@
+package org.scalafmt.sbt
+
+import sbt.*
+
+object ScalafmtPluginConfigurations {
+  val supported = Seq(Compile, Test)
+}

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -500,11 +500,12 @@ object ScalafmtPlugin extends AutoPlugin {
     ScopeFilter(configurations = inAnyConfiguration)
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    Seq(Compile, Test, IntegrationTest).flatMap(scalafmtConfigSettings) ++ Seq(
-      scalafmtAll := scalafmt.?.all(anyConfigsInThisProject).unit.value,
-      scalafmtCheckAll := scalafmtCheck.?.all(anyConfigsInThisProject)
-        .unit.value,
-    )
+    ScalafmtPluginConfigurations.supported.flatMap(scalafmtConfigSettings) ++
+      Seq(
+        scalafmtAll := scalafmt.?.all(anyConfigsInThisProject).unit.value,
+        scalafmtCheckAll := scalafmtCheck.?.all(anyConfigsInThisProject)
+          .unit.value,
+      )
 
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(scalafmtConfig := (ThisBuild / baseDirectory).value / ".scalafmt.conf")


### PR DESCRIPTION
IntegrationTest scope has been completely removed in sbt 2.0.0-rc2.

see sbt/sbt#8184 for context.