### PR TITLE
fix: prevent Scala stdlib filtering in transitive plugin scenarios

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
@@ -36,8 +36,8 @@ class ScalafmtSbtDependencyDownloader(
       configurations = Vector.empty,
       checkExplicit = true,
       filterImplicit = false, // must include scala-library in resolved jars;
-        // the classloader is fully isolated (parent = null), so all
-        // dependencies must be explicitly present (#440)
+      // the classloader is fully isolated (parent = null), so all
+      // dependencies must be explicitly present (#440)
       overrideScalaVersion = false, // disables autoScalaLibrary
     )
     val moduleDependencies = dependencies.asScala

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
@@ -35,7 +35,9 @@ class ScalafmtSbtDependencyDownloader(
       scalaBinaryVersion = lm.CrossVersion.binaryScalaVersion(scalaVersion),
       configurations = Vector.empty,
       checkExplicit = true,
-      filterImplicit = true,
+      filterImplicit = false, // must include scala-library in resolved jars;
+        // the classloader is fully isolated (parent = null), so all
+        // dependencies must be explicitly present (#440)
       overrideScalaVersion = false, // disables autoScalaLibrary
     )
     val moduleDependencies = dependencies.asScala


### PR DESCRIPTION
### Problem

When sbt-scalafmt 2.6.0 is consumed **transitively** through another sbt plugin (e.g., an org-wide auto-plugin that bundles `addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")`), the `scalafmtAll` task fails with:

```
[error] (Compile / scalafmtAll) corrupted class path
```

This works correctly when sbt-scalafmt is added directly in the downstream project's `plugins.sbt`.

### Root Cause

`ScalafmtSbtDependencyDownloader.download()` creates a temp module with `ScalaModuleInfo(filterImplicit = true)`. This tells sbt's dependency resolution to filter out "implicit" Scala library dependencies from the resolved artifacts.

The resolved jars are then loaded into `new URLClassLoader(urls, null)` — a **fully isolated classloader with no parent**. `ScalafmtReflect` immediately tries to load `scala.collection.immutable.Set` and `scala.Option` from this classloader.

When sbt-scalafmt is consumed transitively, sbt's resolution context differs: the Scala 2.13 standard library jars (needed by `scalafmt-core_2.13`) may be classified as "implicit" and filtered from `UpdateReport.allFiles`. Since the classloader has no parent (no fallback to the plugin classloader), the reflection fails with `ReflectiveOperationException`, wrapped as `CorruptedClassPath`.

Key chain:
1. `filterImplicit = true` → sbt filters `scala-library` from resolved files
2. `URLClassLoader(urls, null)` → no parent classloader fallback  
3. `ScalafmtReflect` loads `scala.Option` → `ClassNotFoundException`
4. Caught as `ReflectiveOperationException` → `CorruptedClassPath`

### Fix

Set `filterImplicit = false` so that Scala standard library jars are always included in the resolution. This is safe because:

- The isolated classloader (`parent = null`) **requires** all jars to be present — there is no parent to fall back to
- The temp module needs Scala 2.13.x libs regardless of the build's Scala version (2.12 for sbt)
- The artifacts are already fully qualified (e.g., `scalafmt-core_2.13`), so cross-versioning behavior from `ScalaModuleInfo` is not relied upon
- `overrideScalaVersion = false` already disables `autoScalaLibrary`, so this change only affects filtering of transitively resolved jars

Fixes #440.