### PR TITLE
strip project resolution policy from scalafmt-cli's resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,15 @@ lazy val plugin = project.enablePlugins(SbtPlugin, ScriptedPlugin).settings(
     "org.scalameta" %% "scalafmt-sysops" % scalafmtVersion,
     "org.scalameta" %% "scalafmt-dynamic-core" % scalafmtVersion,
   ),
+  libraryDependencies ++= {
+    // scaladoc reads lm-coursier's TASTy, which references the compile-time-only
+    // @dataclass.data annotation; same workaround as in sbt's own build
+    // (sbt/sbt, modules depending on lm-coursier), see
+    // https://github.com/scala/scala3/issues/18487
+    if (isScala3.value)
+      List("net.hamnaberg" %% "dataclass-annotation" % "0.3.0" % Provided)
+    else Nil
+  },
   scriptedBufferLog := false,
   scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
   // For compat reasons we have this in here to ensure we are testing against 1.2.8

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -133,7 +133,7 @@ object ScalafmtPlugin extends AutoPlugin {
       currentProject: ResolvedProject,
       filterMode: String,
       errorHandling: ErrorHandling,
-      dependencyResolution: lm.DependencyResolution,
+      csrConfiguration: lmcoursier.CoursierConfiguration,
       updateConfiguration: lm.UpdateConfiguration,
   ) {
     locally {
@@ -184,7 +184,7 @@ object ScalafmtPlugin extends AutoPlugin {
     private val scalafmtSession = {
       val factory = new ScalafmtSbtDependencyDownloader(
         taskStreams,
-        dependencyResolution,
+        csrConfiguration,
         updateConfiguration,
       )
 
@@ -486,7 +486,7 @@ object ScalafmtPlugin extends AutoPlugin {
           !noThrow && scalafmtFailOnErrors.value,
           scalafmtDetailedError.value,
         ),
-        dependencyResolution.value,
+        csrConfiguration.value,
         updateConfiguration.value,
       )
       func(files, dirs, session)
@@ -534,7 +534,7 @@ object ScalafmtPlugin extends AutoPlugin {
           scalafmtFailOnErrors.value,
           scalafmtDetailedError.value,
         ),
-        dependencyResolution.value,
+        csrConfiguration.value,
         updateConfiguration.value,
       ).formatSources(absFiles, Nil)
     },

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtSbtDependencyDownloader.scala
@@ -14,9 +14,23 @@ import org.scalafmt.interfaces.*
 
 class ScalafmtSbtDependencyDownloader(
     taskStreams: TaskStreams,
-    dependencyResolution: lm.DependencyResolution,
+    csrConfiguration: lmcoursier.CoursierConfiguration,
     updateConfiguration: lm.UpdateConfiguration,
 ) extends RepositoryPackageDownloaderFactory with RepositoryPackageDownloader {
+  // 2.6.0 (537203c) switched from a bundled coursier to sbt's resolver, so
+  // the project's csrConfiguration now flows into scalafmt-cli's parent-null
+  // URLClassLoader. Keep the infrastructure (resolvers, credentials, cache),
+  // strip the policy — those are rules for the user's deps, not ours.
+  private val dependencyResolution: lm.DependencyResolution = lmcoursier
+    .CoursierDependencyResolution(
+      csrConfiguration.withForceVersions(Vector.empty)
+        .withExcludeDependencies(Vector.empty).withReconciliation(Vector.empty)
+        .withStrict(None).withSameVersions(Seq.empty)
+        .withFallbackDependencies(Vector.empty)
+        .withInterProjectDependencies(Vector.empty)
+        .withExtraProjects(Vector.empty),
+    )
+
   override def create(
       reporter: ScalafmtReporter,
       properties: RepositoryProperties,

--- a/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/.scalafmt.conf
+++ b/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.11.1"
+runner.dialect = scala213

--- a/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/build.sbt
@@ -1,0 +1,11 @@
+inThisBuild(
+  Seq(
+    scalaVersion := "2.13.18",
+    dependencyOverrides += "org.scala-lang" % "scala-library" % "2.13.18",
+    excludeDependencies += "org.scala-lang" % "scala-library",
+  )
+)
+
+lazy val root = (project in file(".")).settings(
+  name := "dep-overrides"
+)

--- a/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/project/plugins.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/src/main/scala/Hello.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Hello {
+  def main(args: Array[String]): Unit = println("hi")
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/dep-overrides/test
@@ -1,0 +1,2 @@
+> scalafmt
+> scalafmtCheck


### PR DESCRIPTION
2.6.0 (537203c) switched from scalafmt-dynamic's bundled coursier to sbt's DependencyResolution. That gave us the project's resolvers and credentials for free, but also its resolution policy (forceVersions, excludeDependencies, etc.). This influences how scalafmt-cli itself is fetched, and actively breaks it.

Most visible failure: scalafmt runs inside sbt on 2.12 and asks for scalafmt-core_2.12. A user `dependencyOverrides += scala-library:2.13.x` yields the wrong stdlib into the URLClassLoader.

Build a fresh CoursierDependencyResolution from csrConfiguration with the policy fields cleared.

Related: #440 — same shape (resolver state into parent-null URLClassLoader), other half of the problem.