### PR TITLE
Avoid redundant getCanonicalFile in asRelative

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -200,9 +200,10 @@ object ScalafmtPlugin extends AutoPlugin {
 
     private lazy val baseDir: Path = currentProject.base.getCanonicalFile.toPath
 
+    // sources reaching this method have already been canonicalized in filterFiles
     @inline
-    private def asRelative(file: File): String = baseDir
-      .relativize(file.getCanonicalFile.toPath).toString
+    private def asRelative(file: File): String = baseDir.relativize(file.toPath)
+      .toString
 
     private def filterFiles(sources: Seq[File], dirs: Seq[File]): Seq[File] = {
       val filter = getFileFilter(dirs)


### PR DESCRIPTION
Every file reaching asRelative has already been canonicalized in filterFiles, so the second getCanonicalFile was a redundant syscall (per file, on the check-warning path).