### PR TITLE
Add scalafmtParallelism setting, thread through FormatSession

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -2,6 +2,8 @@ package org.scalafmt.sbt
 
 import java.io.OutputStreamWriter
 import java.nio.file.{Files, Path}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Callable, ExecutionException, Executors}
 
 import sbt.Keys.*
 import sbt.librarymanagement as lm
@@ -248,36 +250,63 @@ object ScalafmtPlugin extends AutoPlugin {
       }
     }
 
-    private def withFormattedSources[T](initial: T, sources: Seq[File])(
-        onFormat: (T, File, Input, Output) => T,
-    ): T = {
-      var res = initial
-      var good = 0
-      var bad = 0
-      sources.foreach { file =>
+    // Reads and formats each source. The (thread-safe) read+format step may run
+    // concurrently when parallelism > 1; onFormat is always invoked
+    // sequentially, in source order, for files whose formatting changed them, so
+    // callers need no synchronization of their own.
+    private def withFormattedSources(
+        sources: Seq[File],
+    )(onFormat: (File, Input, Output) => Unit): Unit = {
+      val good = new AtomicInteger
+      val bad = new AtomicInteger
+      // returns the changed triple, or None if unreadable, failed or unchanged;
+      // may throw (via reporter.error) when errorHandling.failOnErrors is set
+      def formatOne(file: File): Option[(File, Input, Output)] = {
         val path = file.toPath.toAbsolutePath
         Try(IO.read(file)) match {
           case Failure(x) =>
             reporter.error(path, "Failed to read", x)
-            bad += 1
+            bad.incrementAndGet()
+            None
           case Success(x) =>
             val output = scalafmtSession.formatOrError(path, x)
             /* no need to report on exception since for all errors
              * reporter.error would have been called already */
             Option(output.value) match {
-              case None => bad += 1
+              case None =>
+                bad.incrementAndGet()
+                None
               case Some(o) =>
-                if (x == o) good += 1 else res = onFormat(res, file, x, o)
+                if (x == o) { good.incrementAndGet(); None }
+                else Some((file, x, o))
             }
         }
       }
-      if (bad != 0) {
-        val err = s"failed for $bad sources"
+      val changed: Seq[(File, Input, Output)] =
+        if (parallelism <= 1 || sources.lengthCompare(1) <= 0) sources
+          .flatMap(formatOne)
+        else {
+          val pool = Executors.newFixedThreadPool(parallelism)
+          try {
+            val futures = sources.map { file =>
+              pool.submit(new Callable[Option[(File, Input, Output)]] {
+                override def call() = formatOne(file)
+              })
+            }
+            futures.flatMap { f =>
+              try f.get()
+              catch { case e: ExecutionException => throw e.getCause }
+            }
+          } finally pool.shutdown()
+        }
+      changed.foreach { case (file, in, out) => onFormat(file, in, out) }
+      val badCount = bad.get()
+      if (badCount != 0) {
+        val err = s"failed for $badCount sources"
         if (!errorHandling.failOnErrors) log.error(err)
         else throw messageException(err)
       }
-      log.debug(s"Unchanged $good Scala sources")
-      res
+      log.debug(s"Unchanged ${good.get()} Scala sources")
     }
 
     def formatTrackedSources(sources: Seq[File], dirs: Seq[File]): Unit = {
@@ -303,9 +332,10 @@ object ScalafmtPlugin extends AutoPlugin {
     private def formatFilteredSources(sources: Seq[File]): Unit = {
       if (sources.nonEmpty) log
         .info(s"Formatting ${sources.length} Scala sources ($baseDir)...")
-      val cnt = withFormattedSources(0, sources) { (res, file, _, output) =>
+      var cnt = 0
+      withFormattedSources(sources) { (file, _, output) =>
         IO.write(file, output)
-        res + 1
+        cnt += 1
       }
       if (cnt > 0) log.info(s"Reformatted $cnt Scala sources")
     }
@@ -339,7 +369,7 @@ object ScalafmtPlugin extends AutoPlugin {
       if (sources.nonEmpty) log
         .info(s"Checking ${sources.size} Scala sources ($baseDir)...")
       val unformatted = Set.newBuilder[File]
-      withFormattedSources((), sources) { (_, file, input, output) =>
+      withFormattedSources(sources) { (file, input, output) =>
         val diff =
           if (errorHandling.printDiff) DiffUtils
             .unifiedDiff("/" + asRelative(file), input, output)
@@ -354,7 +384,6 @@ object ScalafmtPlugin extends AutoPlugin {
           }
         log.warn(msg)
         unformatted += file
-        ()
       }
       ScalafmtAnalysis(failedScalafmtCheck = unformatted.result())
     }

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -71,6 +71,12 @@ object ScalafmtPlugin extends AutoPlugin {
     )
     val scalafmtPrintDiff =
       settingKey[Boolean]("Enables full diff output when running check.")
+    val scalafmtParallelism = settingKey[Int](
+      "Maximum number of threads used to format files within a single task " +
+        "(per project/configuration). Default 1 (sequential). Higher values " +
+        "format many files concurrently, but each simultaneous scalafmt task " +
+        "will use up to this many threads.",
+    )
   }
 
   import autoImport.*
@@ -135,6 +141,7 @@ object ScalafmtPlugin extends AutoPlugin {
       errorHandling: ErrorHandling,
       csrConfiguration: lmcoursier.CoursierConfiguration,
       updateConfiguration: lm.UpdateConfiguration,
+      parallelism: Int,
   ) {
     locally {
       import Ordering.Implicits.*
@@ -488,6 +495,7 @@ object ScalafmtPlugin extends AutoPlugin {
         ),
         csrConfiguration.value,
         updateConfiguration.value,
+        scalafmtParallelism.value,
       )
       func(files, dirs, session)
     }
@@ -536,6 +544,7 @@ object ScalafmtPlugin extends AutoPlugin {
         ),
         csrConfiguration.value,
         updateConfiguration.value,
+        scalafmtParallelism.value,
       ).formatSources(absFiles, Nil)
     },
   ))
@@ -561,6 +570,7 @@ object ScalafmtPlugin extends AutoPlugin {
     scalafmtFailOnErrors := true,
     scalafmtPrintDiff := false,
     scalafmtDetailedError := false,
+    scalafmtParallelism := 1,
   )
 
   private def getFileMatcher(paths: Seq[Path]): Path => Boolean = {

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -97,6 +97,10 @@ lazy val p20 = project.settings(
   scalafmtConfig := file(".scalafmt20.conf"),
   scalaVersion := "2.12.21"
 )
+lazy val p21 = project.settings(
+  scalaVersion := "2.12.21",
+  scalafmtParallelism := 4
+)
 
 def assertContentsEqual(file: File, expected: String): Unit = {
   val obtained =
@@ -282,6 +286,24 @@ InputKey[Unit]("check") := {
   )
 }
 
+
+InputKey[Unit]("checkP21") := {
+  def expected(name: String) =
+    s"""
+       |object Obj$name {
+       |  def foo(
+       |    a: Int, // comment
+       |    b: Double
+       |  ) = ???
+       |}
+    """.stripMargin
+  Seq("A", "B", "C", "D", "E", "F").foreach { n =>
+    assertContentsEqual(file(s"p21/src/main/scala/$n.scala"), expected(n))
+  }
+  Seq("G", "H").foreach { n =>
+    assertContentsEqual(file(s"p21/src/test/scala/$n.scala"), expected(n))
+  }
+}
 
 InputKey[Unit]("checkManagedSources") := {
   assertContentsEqual(

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/A.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/A.scala
@@ -1,0 +1,6 @@
+object
+ObjA
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/B.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/B.scala
@@ -1,0 +1,6 @@
+object
+ObjB
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/C.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/C.scala
@@ -1,0 +1,6 @@
+object
+ObjC
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/D.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/D.scala
@@ -1,0 +1,6 @@
+object
+ObjD
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/E.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/E.scala
@@ -1,0 +1,6 @@
+object
+ObjE
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/F.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/main/scala/F.scala
@@ -1,0 +1,6 @@
+object
+ObjF
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/test/scala/G.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/test/scala/G.scala
@@ -1,0 +1,6 @@
+object
+ObjG
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/test/scala/H.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/p21/src/test/scala/H.scala
@@ -1,0 +1,6 @@
+object
+ObjH
+{
+  def foo(a: Int, // comment
+    b: Double) = ???
+}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -230,3 +230,12 @@ $ copy-file changes/target/managed.scala project/target/managed.scala
 $ copy-file changes/x/Something.scala project/x/Something.scala
 > scalafmtSbt
 > checkManagedSources
+
+# parallel formatting (scalafmtParallelism > 1) across many files
+-> p21/Compile/scalafmtCheck
+-> p21/Test/scalafmtCheck
+> p21/Compile/scalafmt
+> p21/Test/scalafmt
+> p21/Compile/scalafmtCheck
+> p21/Test/scalafmtCheck
+> checkP21


### PR DESCRIPTION
Plumbing only, no behavior change: introduces the scalafmtParallelism setting (default 1), passes it into FormatSession from both construction sites, and adds the global default. The value is not consumed yet.