### PR TITLE
Fix ScalafmtLogger.success infinite self-recursion

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -118,7 +118,7 @@ object ScalafmtPlugin extends AutoPlugin {
 
   private class ScalafmtLogger(log: Logger) extends Logger {
     override def trace(t: => Throwable): Unit = log.trace(t)
-    override def success(message: => String): Unit = success(message)
+    override def success(message: => String): Unit = log.success(message)
     override def log(level: Level.Value, message: => String): Unit = log
       .log(level, getLogMessage(message))
   }


### PR DESCRIPTION
success delegated to itself instead of the wrapped logger, so any call would StackOverflow. Delegate to log.success, like trace and log.