### PR TITLE
Make scalafmtOnly format explicitly-named files

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -565,7 +565,8 @@ object ScalafmtPlugin extends AutoPlugin {
         fullResolvers.value,
         credentials.value,
         thisProject.value,
-        "",
+        // files are named explicitly, so don't filter them by git tracking
+        FilterMode.none,
         new ErrorHandling(
           scalafmtPrintDiff.value,
           scalafmtLogOnEachError.value,

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/.scalafmt22.conf
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/.scalafmt22.conf
@@ -1,0 +1,3 @@
+version = 2.2.1
+style = IntelliJ
+project.git = true

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -101,6 +101,10 @@ lazy val p21 = project.settings(
   scalaVersion := "2.12.21",
   scalafmtParallelism := 4
 )
+lazy val p22 = project.settings(
+  scalaVersion := "2.12.21",
+  scalafmtConfig := file(".scalafmt22.conf")
+)
 
 def assertContentsEqual(file: File, expected: String): Unit = {
   val obtained =

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -239,3 +239,9 @@ $ copy-file changes/x/Something.scala project/x/Something.scala
 > p21/Compile/scalafmtCheck
 > p21/Test/scalafmtCheck
 > checkP21
+
+# scalafmtOnly must format an explicitly-named file even if untracked by git
+$ exec git init -b main p22
+$ copy-file changes/bad.scala p22/src/main/scala/OnlyFile.scala
+> p22/scalafmtOnly src/main/scala/OnlyFile.scala
+$ must-mirror p22/src/main/scala/OnlyFile.scala changes/good.scala


### PR DESCRIPTION
scalafmtOnly passed filterMode "", which is not "none", so on a project with project.git = true it ran explicitly-named files through the git ls-tree filter and silently skipped any that weren't tracked -- despite the task's contract to "format a single given file". Pass FilterMode.none so named files are always formatted (project exclude filters still apply).