### PR TITLE
Process sbt build files on load per scalafmtSbtOnLoad

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -105,6 +105,9 @@ object ScalafmtPlugin extends AutoPlugin {
   private val scalafmtNoThrow =
     taskKey[Unit]("Format Scala sources with scalafmt, ignore failures.")
 
+  private val scalafmtSbtCheckOnLoad =
+    taskKey[Unit]("Run scalafmtSbtCheck on load, warning instead of failing.")
+
   private val scalaConfig = scalafmtConfig.map { f =>
     if (f.exists()) f.toPath
     else throw messageException(s"File does not exist: ${f.toPath}")
@@ -605,6 +608,16 @@ object ScalafmtPlugin extends AutoPlugin {
     scalafmtSbtCheck := getScalafmtSbtTasks(scalafmtSbtCheckTask).value,
     scalafmtNoThrow :=
       getScalafmtSourcesTask(scalafmtTask, noThrow = true).result.unit.value,
+    scalafmtSbtCheckOnLoad := {
+      val log = streams.value.log
+      // don't let a load-time check fail sbt startup: warn instead. Match on
+      // Result.toEither (Left = failed) since Inc/Value differ between sbt 1 & 2
+      scalafmtSbtCheck.result.value.toEither match {
+        case Left(_) =>
+          log.warn("scalafmt: *.sbt or project/*.scala are not formatted; run scalafmtSbt")
+        case Right(_) =>
+      }
+    },
     scalafmtDoFormatOnCompile := Def.settingDyn {
       if (scalafmtOnCompile.value) resolvedScoped.value.scope / scalafmtNoThrow
       else Def.task(())
@@ -671,6 +684,19 @@ object ScalafmtPlugin extends AutoPlugin {
     scalafmtDetailedError := false,
     scalafmtParallelism := 1,
     scalafmtSbtOnLoad := SbtOnLoad.off,
+    // sbt build files are (re)compiled on load, not on `compile`, so hook the
+    // load lifecycle to keep them formatted (see #2)
+    Global / onLoad := {
+      val transition: State => State = { state =>
+        Project.extract(state).getOpt(scalafmtSbtOnLoad) match {
+          case Some(SbtOnLoad.run) => "scalafmtSbt" :: state
+          case Some(SbtOnLoad.warn) => "scalafmtSbtCheckOnLoad" :: state
+          case _ => state
+        }
+      }
+      // compose over any onLoad from other plugins rather than replacing it
+      transition.compose((Global / onLoad).value)
+    },
   )
 
   private def getFileMatcher(paths: Seq[Path]): Path => Boolean = {

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -82,6 +82,8 @@ object ScalafmtPlugin extends AutoPlugin {
       settingKey[Boolean]("Enables full diff output when running check.")
     val scalafmtParallelism =
       settingKey[Int]("Number of threads to format files within a task; 1 (default) is sequential.")
+    val scalafmtSbtOnLoad =
+      settingKey[String]("Process build files on sbt (re)load: \"off\" (default), \"run\", or \"warn\".")
   }
 
   import autoImport.*
@@ -120,6 +122,12 @@ object ScalafmtPlugin extends AutoPlugin {
     val diffDirty = "diff-dirty"
     val diffRefPrefix = "diff-ref="
     val none = "none"
+  }
+
+  private object SbtOnLoad {
+    val off = "off"
+    val run = "run"
+    val warn = "warn"
   }
 
   private def getLogMessage(message: String): String = "scalafmt: " + message
@@ -662,6 +670,7 @@ object ScalafmtPlugin extends AutoPlugin {
     scalafmtPrintDiff := false,
     scalafmtDetailedError := false,
     scalafmtParallelism := 1,
+    scalafmtSbtOnLoad := SbtOnLoad.off,
   )
 
   private def getFileMatcher(paths: Seq[Path]): Path => Boolean = {

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/.scalafmt.conf
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 3.11.3
+runner.dialect = scala213

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/build.sbt
@@ -1,0 +1,2 @@
+scalaVersion := "2.12.21"
+ThisBuild / scalafmtSbtOnLoad := "warn"

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/expected/Foo.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/expected/Foo.scala
@@ -1,0 +1,1 @@
+object Foo  {  }

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/project/Foo.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/project/Foo.scala
@@ -1,0 +1,1 @@
+object Foo  {  }

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/project/plugins.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/scalafmt-sbt/onload-warn/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload-warn/test
@@ -1,0 +1,2 @@
+# warn mode: load succeeds (warning only), build file left unformatted
+$ must-mirror project/Foo.scala expected/Foo.scala

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/.scalafmt.conf
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 3.11.3
+runner.dialect = scala213

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/build.sbt
@@ -1,0 +1,2 @@
+scalaVersion := "2.12.21"
+ThisBuild / scalafmtSbtOnLoad := "run"

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/expected/Foo.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/expected/Foo.scala
@@ -1,0 +1,1 @@
+object Foo  {  }

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/expected/Foo.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/expected/Foo.scala
@@ -1,1 +1,1 @@
-object Foo  {  }
+object Foo {}

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/project/Foo.scala
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/project/Foo.scala
@@ -1,0 +1,1 @@
+object Foo  {  }

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/project/plugins.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/scalafmt-sbt/onload/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/onload/test
@@ -1,0 +1,2 @@
+# run mode: metabuild file formatted on load
+$ must-mirror project/Foo.scala expected/Foo.scala


### PR DESCRIPTION
Compose Global / onLoad to run scalafmtSbt ("run") or, non-fatally, scalafmtSbtCheck ("warn") on every (re)load, so *.sbt and project/*.scala stay formatted without a separate step (#2). "warn" routes through a helper that swallows the check failure and logs instead, so a mis-formatted build file never blocks sbt startup. Fixes #2.
