### PR TITLE
Exclude project/target from scalafmtSbt .sbt discovery

### DIFF
--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -484,9 +484,7 @@ object ScalafmtPlugin extends AutoPlugin {
     val thisBase = thisProject.value.base
     val rootSbt = BuildPaths.configurationSources(thisBase).filterNot(_.isHidden)
     val metabuildSbt =
-      if (rootBase == thisBase)
-        (BuildPaths.projectStandard(thisBase) ** GlobFilter("*.sbt")).get()
-      else Nil
+      if (rootBase == thisBase) metabuildDescendants(thisBase, "*.sbt") else Nil
     rootSbt ++ metabuildSbt
   }
 

--- a/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -467,6 +467,18 @@ object ScalafmtPlugin extends AutoPlugin {
     }
   }
 
+  // Descendants of the build's project/ directory matching glob, excluding the
+  // metabuild's own target/ output (which scalafmt should never format).
+  private def metabuildDescendants(base: File, glob: String): Seq[File] = {
+    val projectDirectory = BuildPaths.projectStandard(base)
+    val targetDirectory = BuildPaths.outputDirectory(projectDirectory)
+      .getAbsolutePath
+    projectDirectory.descendantsExcept(
+      glob,
+      (pathname: File) => pathname.getAbsolutePath.startsWith(targetDirectory),
+    ).get()
+  }
+
   private lazy val sbtSources = Def.task {
     val rootBase = (LocalRootProject / baseDirectory).value
     val thisBase = thisProject.value.base
@@ -481,16 +493,7 @@ object ScalafmtPlugin extends AutoPlugin {
   private lazy val metabuildSources = Def.task {
     val rootBase = (LocalRootProject / baseDirectory).value
     val thisBase = thisProject.value.base
-
-    if (rootBase == thisBase) {
-      val projectDirectory = BuildPaths.projectStandard(thisBase)
-      val targetDirectory = BuildPaths.outputDirectory(projectDirectory)
-        .getAbsolutePath
-      projectDirectory.descendantsExcept(
-        "*.scala",
-        (pathname: File) => pathname.getAbsolutePath.startsWith(targetDirectory),
-      ).get()
-    } else Nil
+    if (rootBase == thisBase) metabuildDescendants(thisBase, "*.scala") else Nil
   }
 
   private def scalafmtTask(

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -338,14 +338,12 @@ InputKey[Unit]("checkManagedSources") := {
       |""".stripMargin
   )
 
-  // BUG: managed.sbt is under project/target and should be left untouched
-  // like the adjacent *.scala scan does, but the *.sbt scan reformats it
   assertContentsEqual(
     file("project/target/managed.sbt"),
     """
       |// don't touch me!!!
       |
-      |object a {}
+      |object a       {}
       |""".stripMargin
   )
 }

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/build.sbt
@@ -329,4 +329,23 @@ InputKey[Unit]("checkManagedSources") := {
       |object a       {}
       |""".stripMargin
   )
+
+  assertContentsEqual(
+    file("project/x/Something.sbt"),
+    """
+      |// format me
+      |object kek {}
+      |""".stripMargin
+  )
+
+  // BUG: managed.sbt is under project/target and should be left untouched
+  // like the adjacent *.scala scan does, but the *.sbt scan reformats it
+  assertContentsEqual(
+    file("project/target/managed.sbt"),
+    """
+      |// don't touch me!!!
+      |
+      |object a {}
+      |""".stripMargin
+  )
 }

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/target/managed.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/target/managed.sbt
@@ -1,0 +1,3 @@
+// don't touch me!!!
+
+object a       {}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/x/Something.sbt
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/changes/x/Something.sbt
@@ -1,0 +1,2 @@
+// format me
+object kek    {}

--- a/plugin/src/sbt-test/scalafmt-sbt/sbt/test
+++ b/plugin/src/sbt-test/scalafmt-sbt/sbt/test
@@ -228,6 +228,8 @@ $ exec git -C p20 add src/main/scala/TestInvalid1.scala
 
 $ copy-file changes/target/managed.scala project/target/managed.scala
 $ copy-file changes/x/Something.scala project/x/Something.scala
+$ copy-file changes/target/managed.sbt project/target/managed.sbt
+$ copy-file changes/x/Something.sbt project/x/Something.sbt
 > scalafmtSbt
 > checkManagedSources
 


### PR DESCRIPTION
scalafmtSbt gathered *.sbt anywhere under project/ via a bare ** glob, including project/target/, while the adjacent *.scala scan already excluded that output directory via metabuildDescendants. Route the *.sbt scan through the same helper so both skip the metabuild's target/ output.
